### PR TITLE
Feature/named deployment registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,20 @@
-# Copy file to .env and fill in the values
-ANTHROPIC_API_KEY=''
-OPENAI_API_KEY=''
-GOOGLE_API_KEY=''
+# Copy file to .env and fill in the values.
+# Each model deployment in the registry names exactly one of these variables as
+# its credential (see langchain_registry.py). Only set the ones you actually use.
+
+# ── Vendor-direct deployments ────────────────────────────────────────────────
+ANTHROPIC_API_KEY=''   # claude-* deployments
+OPENAI_API_KEY=''      # gpt-*, o1/o3/o4 deployments
+GOOGLE_API_KEY=''      # gemini-* deployments
+DEEPSEEK_API_KEY=''    # deepseek-* deployments
+ZAI_API_KEY=''         # glm-5.2 (z.ai OpenAI-compatible endpoint)
+OPENROUTER_API_KEY=''  # kimi-k3 (Moonshot via OpenRouter)
+# OPENROUTER_BASE_URL=''  # optional override; defaults to https://openrouter.ai/api/v1
+
+# ── LiteLLM proxy (the *-litellm deployments) ────────────────────────────────
+# One OpenAI-compatible endpoint + key that fans out to many models.
+LITELLM_API_KEY=''
+LITELLM_BASE_URL=''    # e.g. https://ai-gateway.andrew.cmu.edu/v1
 
 DEBUG=false
 DEBUG_PORT=5678

--- a/incalmo/core/strategies/llm/langchain_registry.py
+++ b/incalmo/core/strategies/llm/langchain_registry.py
@@ -4,235 +4,300 @@ from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_deepseek import ChatDeepSeek
-from typing import Dict, Any
+from typing import Any, Callable, Dict, Optional
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Named-deployment registry
+#
+# Each entry is a *deployment*: an explicit binding of
+#   logical name  →  { provider adapter, endpoint, credential, upstream model }
+#
+# The credential is referenced by the *name* of an environment variable
+# (`credential_ref`), never the secret value, and it is resolved fail-fast at
+# get_model() time. This guarantees the intended key is used for the intended
+# deployment — no reliance on a provider SDK silently reading an ambient env var.
+#
+# `base_url` may be a literal URL, None (use the provider default), or an
+# "env/VAR" reference resolved at build time (used for the LiteLLM proxy, whose
+# URL lives in the environment rather than in code).
+#
+# To route a model through the vendor's own API vs a LiteLLM proxy, pick the
+# corresponding named deployment (e.g. "claude-opus-5" vs "claude-opus-5-litellm").
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _resolve(value: Optional[str]) -> Optional[str]:
+    """Resolve an 'env/VAR' indirection to its environment value; pass through otherwise."""
+    if value and value.startswith("env/"):
+        var = value[len("env/") :]
+        resolved = os.environ.get(var)
+        if not resolved:
+            raise RuntimeError(
+                f"Deployment references base_url '{value}', but env var '{var}' is unset."
+            )
+        return resolved
+    return value
+
+
+# ── Provider adapters: how to build each client and WHERE the key is injected ──
+def _build_openai(d: dict, key: str):
+    kwargs: Dict[str, Any] = dict(model=d["model"], api_key=key, **d.get("params", {}))
+    base_url = _resolve(d.get("base_url"))
+    if base_url:
+        kwargs["base_url"] = base_url
+    return ChatOpenAI(**kwargs)
+
+
+def _build_anthropic(d: dict, key: str):
+    kwargs: Dict[str, Any] = dict(
+        model_name=d["model"], api_key=key, **d.get("params", {})
+    )
+    base_url = _resolve(d.get("base_url"))
+    if base_url:
+        kwargs["base_url"] = base_url
+    return ChatAnthropic(**kwargs)
+
+
+def _build_google(d: dict, key: str):
+    return ChatGoogleGenerativeAI(
+        model=d["model"], google_api_key=key, **d.get("params", {})
+    )
+
+
+def _build_deepseek(d: dict, key: str):
+    kwargs: Dict[str, Any] = dict(model=d["model"], api_key=key, **d.get("params", {}))
+    base_url = _resolve(d.get("base_url"))
+    if base_url:
+        kwargs["api_base"] = base_url
+    return ChatDeepSeek(**kwargs)
+
+
+_ADAPTERS: Dict[str, Callable[[dict, str], Any]] = {
+    "openai": _build_openai,
+    # OpenAI-compatible surface: OpenAI direct, Azure, GLM/z.ai, and LiteLLM all land here.
+    "openai_compatible": _build_openai,
+    "anthropic": _build_anthropic,
+    "google": _build_google,
+    "deepseek": _build_deepseek,
+}
+
+
+# ── Compact tables of direct (vendor-native) deployments ─────────────────────
+_ANTHROPIC_STD = {"temperature": 0.7, "timeout": None, "stop": None}
+_ANTHROPIC_C5 = {"temperature": 1, "timeout": None, "stop": None}  # Claude 5 requires temp=1
+
+# name -> upstream OpenAI model id
+_OPENAI_DIRECT = {
+    "gpt-3.5-turbo": "gpt-3.5-turbo",
+    "gpt-4": "gpt-4",
+    "gpt-4o": "gpt-4o",
+    "gpt-4o-mini": "gpt-4o-mini",
+    "gpt-4.1": "gpt-4.1",
+    "gpt-4.1-mini": "gpt-4.1-mini",
+    "gpt-4.1-nano": "gpt-4.1-nano",
+    "gpt-o1": "o1-preview",  # LEGACY alias
+    "o1": "o1",
+    "o1-mini": "o1-mini",
+    "o1-pro": "o1-pro",
+    "o3-mini": "o3-mini",
+    "o3": "o3",
+    "o3-pro": "o3-pro",
+    "o4-mini": "o4-mini",
+    "gpt-5": "gpt-5",
+    "gpt-5-mini": "gpt-5-mini",
+    "gpt-5-nano": "gpt-5-nano",
+    "gpt-5.2": "gpt-5.2",
+    "gpt-5.2-pro": "gpt-5.2-pro",
+    "gpt-5.4-mini": "gpt-5.4-mini",
+    "gpt-5.4": "gpt-5.4",
+    "gpt-5.4-pro": "gpt-5.4-pro-2026-03-05",
+    "gpt-5.5": "gpt-5.5",
+    "gpt-5.6-luna": "gpt-5.6-luna",
+    "gpt-5.6-sol": "gpt-5.6-sol",
+    "gpt-5.6-terra": "gpt-5.6-terra",
+}
+
+# name -> (upstream anthropic model id, params)
+_ANTHROPIC_DIRECT = {
+    "claude-3-opus": ("claude-3-opus-latest", _ANTHROPIC_STD),
+    "claude-3-sonnet": ("claude-3-sonnet-20240229", _ANTHROPIC_STD),
+    "claude-3-haiku": ("claude-3-haiku-20240307", _ANTHROPIC_STD),
+    "claude-3.5-sonnet": ("claude-3-5-sonnet-latest", _ANTHROPIC_STD),
+    "claude-3.5-haiku": ("claude-3-5-haiku-latest", _ANTHROPIC_STD),
+    "claude-3.7-sonnet": ("claude-3-7-sonnet-latest", _ANTHROPIC_STD),
+    "claude-4.0-sonnet": ("claude-sonnet-4-0", _ANTHROPIC_STD),
+    "claude-4.5-sonnet": ("claude-sonnet-4-5-20250929", _ANTHROPIC_STD),
+    "claude-sonnet-4-6": ("claude-sonnet-4-6", _ANTHROPIC_STD),
+    "claude-haiku-4-5": ("claude-haiku-4-5-20251001", _ANTHROPIC_STD),
+    "claude-opus-4-1": ("claude-opus-4-1-20250805", _ANTHROPIC_STD),
+    "claude-opus-4-6": ("claude-opus-4-6", _ANTHROPIC_STD),
+    "claude-opus-5": ("claude-opus-5", _ANTHROPIC_C5),
+    "claude-sonnet-5": ("claude-sonnet-5", _ANTHROPIC_C5),
+    "claude-fable-5": ("claude-fable-5", _ANTHROPIC_C5),
+    "claude-mythos-5": ("claude-mythos-5", _ANTHROPIC_C5),
+}
+
+# name -> upstream gemini model id
+_GOOGLE_DIRECT = {
+    "gemini-1.5-pro": "gemini-1.5-pro",
+    "gemini-1.5-flash": "gemini-1.5-flash",
+    "gemini-2.0-flash": "gemini-2.0-flash",
+    "gemini-2.5-flash": "gemini-2.5-flash",
+    "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+    "gemini-2.5-pro": "gemini-2.5-pro",
+    "gemini-3-flash-preview": "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite-preview",
+    "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+}
+
+# name -> upstream deepseek model id
+_DEEPSEEK_DIRECT = {
+    "deepseek-7b": "deepseek-ai/deepseek-coder-7b-instruct",
+    "deepseek-v3": "deepseek-chat",
+    "deepseek-r1": "deepseek-reasoner",
+}
+
+
+def _build_deployments() -> Dict[str, dict]:
+    d: Dict[str, dict] = {}
+
+    for name, model in _OPENAI_DIRECT.items():
+        d[name] = {
+            "provider": "openai",
+            "model": model,
+            "base_url": None,
+            "credential_ref": "OPENAI_API_KEY",
+            "params": {},
+        }
+
+    for name, (model, params) in _ANTHROPIC_DIRECT.items():
+        d[name] = {
+            "provider": "anthropic",
+            "model": model,
+            "base_url": None,
+            "credential_ref": "ANTHROPIC_API_KEY",
+            "params": dict(params),
+        }
+
+    for name, model in _GOOGLE_DIRECT.items():
+        d[name] = {
+            "provider": "google",
+            "model": model,
+            "base_url": None,
+            "credential_ref": "GOOGLE_API_KEY",
+            "params": {"temperature": 0.7},
+        }
+
+    for name, model in _DEEPSEEK_DIRECT.items():
+        d[name] = {
+            "provider": "deepseek",
+            "model": model,
+            "base_url": None,
+            "credential_ref": "DEEPSEEK_API_KEY",
+            "params": {"temperature": 0.7},
+        }
+
+    # GLM via z.ai's OpenAI-compatible endpoint
+    d["glm-5.2"] = {
+        "provider": "openai_compatible",
+        "model": "glm-5.2",
+        "base_url": "https://api.z.ai/api/paas/v4/",
+        "credential_ref": "ZAI_API_KEY",
+        "params": {"temperature": 0.7},
+    }
+
+    # Kimi (Moonshot) via OpenRouter's OpenAI-compatible endpoint. The CMU
+    # gateway does not carry a Kimi model, so this routes through OpenRouter,
+    # which namespaces models as `vendor/model`. `model` must match OpenRouter's
+    # catalog; base_url is overridable via OPENROUTER_BASE_URL.
+    d["kimi-k3"] = {
+        "provider": "openai_compatible",
+        "model": "moonshotai/kimi-k3",
+        "base_url": os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
+        "credential_ref": "OPENROUTER_API_KEY",
+        "params": {},
+    }
+
+    # ── LiteLLM-proxied named deployments ────────────────────────────────────
+    # Same models, routed through a single OpenAI-compatible LiteLLM endpoint
+    # with a single key. The `model` string here must match a `model_name`
+    # served by the proxy's /v1/models list. base_url + key come from the
+    # environment (LITELLM_BASE_URL / LITELLM_API_KEY).
+    #
+    # These IDs are the ones exposed by the CMU AI gateway
+    # (https://ai-gateway.andrew.cmu.edu/v1) as of setup; re-check /v1/models
+    # if the gateway's catalog changes. No sampling params are set here — each
+    # model uses its own default — matching the OpenAI direct deployments.
+    _LITELLM_MODELS = [
+        # (deployment name, gateway model id)
+        # ── Anthropic (Bedrock-hosted) ──
+        ("claude-sonnet-5-litellm", "us.anthropic.claude-sonnet-5"),
+        ("claude-opus-4-8-litellm", "us.anthropic.claude-opus-4-8"),
+        ("claude-opus-4-7-litellm", "us.anthropic.claude-opus-4-7"),
+        ("claude-opus-4-6-litellm", "us.anthropic.claude-opus-4-6-v1"),
+        ("claude-sonnet-4-6-litellm", "us.anthropic.claude-sonnet-4-6"),
+        ("claude-haiku-4-5-litellm", "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+        # ── OpenAI ──
+        ("gpt-5-mini-litellm", "gpt-5-mini"),
+        ("gpt-5-nano-litellm", "gpt-5-nano"),
+        ("gpt-5.4-mini-litellm", "gpt-5.4-mini"),
+        ("gpt-4.1-mini-litellm", "gpt-4.1-mini"),
+        ("gpt-5.6-sol-litellm", "gpt-5.6-sol"),
+        ("gpt-5.6-terra-litellm", "gpt-5.6-terra"),
+        ("gpt-5.6-luna-litellm", "gpt-5.6-luna"),
+        ("gpt-5.5-litellm", "gpt-5.5"),
+        ("gpt-5.4-litellm", "gpt-5.4"),
+        ("gpt-5.4-pro-litellm", "gpt-5.4-pro"),
+        # ── Google Gemini ──
+        ("gemini-3.1-pro-litellm", "gemini/gemini-3.1-pro-preview"),
+        ("gemini-3.5-flash-litellm", "gemini/gemini-3.5-flash"),
+        ("gemini-2.5-pro-litellm", "gemini/gemini-2.5-pro"),
+    ]
+    for name, model in _LITELLM_MODELS:
+        d[name] = {
+            "provider": "openai_compatible",
+            "model": model,
+            "base_url": "env/LITELLM_BASE_URL",
+            "credential_ref": "LITELLM_API_KEY",
+            "params": {},
+        }
+
+    return d
 
 
 class LangChainRegistry:
     def __init__(self):
-        # Store factory functions, not instances
-        self._model_factories = {
-            # ── OpenAI ─────────────────────────────────────────────────────────
-            # LEGACY – prefer gpt-4o-mini instead
-            "gpt-3.5-turbo": lambda: ChatOpenAI(model="gpt-3.5-turbo"),
-            # LEGACY – superseded by gpt-4o
-            "gpt-4": lambda: ChatOpenAI(model="gpt-4"),
-            # Current flagship multimodal model
-            "gpt-4o": lambda: ChatOpenAI(model="gpt-4o"),
-            # Fast / cost-efficient alternative to gpt-4o
-            "gpt-4o-mini": lambda: ChatOpenAI(model="gpt-4o-mini"),
-            # GPT-4.1 family (Apr 2025)
-            "gpt-4.1": lambda: ChatOpenAI(model="gpt-4.1"),
-            "gpt-4.1-mini": lambda: ChatOpenAI(model="gpt-4.1-mini"),
-            "gpt-4.1-nano": lambda: ChatOpenAI(model="gpt-4.1-nano"),
-            # o-series reasoning models
-            # LEGACY key/alias – o1-preview has been superseded by o1
-            "gpt-o1": lambda: ChatOpenAI(model="o1-preview"),
-            "o1": lambda: ChatOpenAI(model="o1"),
-            "o1-mini": lambda: ChatOpenAI(model="o1-mini"),
-            "o1-pro": lambda: ChatOpenAI(model="o1-pro"),
-            "o3-mini": lambda: ChatOpenAI(model="o3-mini"),
-            "o3": lambda: ChatOpenAI(model="o3"),
-            "o3-pro": lambda: ChatOpenAI(
-                model="o3-pro"
-            ),  # LATEST most-capable reasoning (Jun 2025)
-            "o4-mini": lambda: ChatOpenAI(
-                model="o4-mini"
-            ),  # LATEST fast reasoning (Apr 2025)
-            # GPT-5 family
-            "gpt-5": lambda: ChatOpenAI(model="gpt-5"),
-            "gpt-5-mini": lambda: ChatOpenAI(
-                model="gpt-5-mini"
-            ),  # LATEST mini (Aug 2025)
-            "gpt-5-nano": lambda: ChatOpenAI(
-                model="gpt-5-nano"
-            ),  # LATEST nano (Aug 2025)
-            "gpt-5.2": lambda: ChatOpenAI(
-                model="gpt-5.2"
-            ),  # LATEST standard (Dec 2025)
-            "gpt-5.2-pro": lambda: ChatOpenAI(
-                model="gpt-5.2-pro"
-            ),  # LATEST most capable (Dec 2025)
-            "gpt-5.4-mini": lambda: ChatOpenAI(model="gpt-5.4-mini"),
-            "gpt-5.4": lambda: ChatOpenAI(model="gpt-5.4"),
-            "gpt-5.4-pro": lambda: ChatOpenAI(model="gpt-5.4-pro-2026-03-05"),
-            "gpt-5.5": lambda: ChatOpenAI(model="gpt-5.5"),
-            # GPT-5.6 family (2026) — three named variants, no bare gpt-5.6
-            "gpt-5.6-luna": lambda: ChatOpenAI(model="gpt-5.6-luna"),
-            "gpt-5.6-sol": lambda: ChatOpenAI(model="gpt-5.6-sol"),
-            "gpt-5.6-terra": lambda: ChatOpenAI(model="gpt-5.6-terra"),
-            # ── Anthropic ──────────────────────────────────────────────────────
-            # Claude 3 family – LEGACY
-            "claude-3-opus": lambda: ChatAnthropic(  # LEGACY: superseded by claude-3.7-sonnet+
-                model_name="claude-3-opus-latest",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-3-sonnet": lambda: ChatAnthropic(  # LEGACY: superseded by claude-3.5-sonnet+
-                # retired July 2025; no -latest alias exists, pin the snapshot
-                model_name="claude-3-sonnet-20240229",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-3-haiku": lambda: ChatAnthropic(  # LEGACY: use claude-3.5-haiku or claude-haiku-4-5
-                # retired; no -latest alias exists, pin the snapshot
-                model_name="claude-3-haiku-20240307",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            # Claude 3.5 family
-            "claude-3.5-sonnet": lambda: ChatAnthropic(  # Still widely supported
-                model_name="claude-3-5-sonnet-latest",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-3.5-haiku": lambda: ChatAnthropic(  # Cost-efficient; superseded by claude-haiku-4-5
-                model_name="claude-3-5-haiku-latest",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            # Claude 3.7 family – added extended thinking (Feb 2025)
-            "claude-3.7-sonnet": lambda: ChatAnthropic(
-                model_name="claude-3-7-sonnet-latest",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            # Claude 4 family
-            "claude-4.0-sonnet": lambda: ChatAnthropic(  # Older Claude 4 Sonnet; superseded by 4.5/4.6
-                model_name="claude-sonnet-4-0",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-4.5-sonnet": lambda: ChatAnthropic(  # Superseded by claude-sonnet-4-6
-                model_name="claude-sonnet-4-5-20250929",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-sonnet-4-6": lambda: ChatAnthropic(  # LATEST Claude Sonnet
-                model_name="claude-sonnet-4-6",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-haiku-4-5": lambda: ChatAnthropic(  # LATEST Claude Haiku
-                model_name="claude-haiku-4-5-20251001",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-opus-4-1": lambda: ChatAnthropic(  # Older Claude 4 Opus; superseded by claude-opus-4-6
-                model_name="claude-opus-4-1-20250805",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-opus-4-6": lambda: ChatAnthropic(  # superseded by claude-opus-5
-                model_name="claude-opus-4-6",
-                temperature=0.7,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-opus-5": lambda: ChatAnthropic(  # Claude 5 (Jul 24 2026); Claude 5 only accepts temperature=1
-                model_name="claude-opus-5",
-                temperature=1,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-sonnet-5": lambda: ChatAnthropic(  # Claude 5 Sonnet (Jun 30 2026)
-                model_name="claude-sonnet-5",
-                temperature=1,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-fable-5": lambda: ChatAnthropic(  # Claude 5 Fable frontier (Jun 9 2026)
-                model_name="claude-fable-5",
-                temperature=1,
-                timeout=None,
-                stop=None,
-            ),
-            "claude-mythos-5": lambda: ChatAnthropic(  # Claude 5 Mythos frontier; restricted / trusted-access (Jun 9 2026)
-                model_name="claude-mythos-5",
-                temperature=1,
-                timeout=None,
-                stop=None,
-            ),
-            # ── Google Gemini ──────────────────────────────────────────────────
-            # LEGACY
-            "gemini-1.5-pro": lambda: ChatGoogleGenerativeAI(  # LEGACY: superseded by 2.x
-                model="gemini-1.5-pro", temperature=0.7
-            ),
-            "gemini-1.5-flash": lambda: ChatGoogleGenerativeAI(  # LEGACY: superseded by gemini-2.0-flash
-                model="gemini-1.5-flash", temperature=0.7
-            ),
-            # Current / latest
-            # NOTE: was incorrectly stored as "gemini-2-flash"; correct model ID is "gemini-2.0-flash"
-            "gemini-2.0-flash": lambda: ChatGoogleGenerativeAI(  # LATEST fast model
-                model="gemini-2.0-flash", temperature=0.7
-            ),
-            "gemini-2.5-flash": lambda: ChatGoogleGenerativeAI(
-                model="gemini-2.5-flash", temperature=0.7
-            ),
-            "gemini-2.5-flash-lite": lambda: ChatGoogleGenerativeAI(
-                model="gemini-2.5-flash-lite", temperature=0.7
-            ),
-            "gemini-2.5-pro": lambda: ChatGoogleGenerativeAI(
-                model="gemini-2.5-pro", temperature=0.7
-            ),
-            # Gemini 3 family
-            "gemini-3-flash-preview": lambda: ChatGoogleGenerativeAI(  # LATEST fast Gemini
-                model="gemini-3-flash-preview", temperature=0.7
-            ),
-            "gemini-3.1-flash-lite-preview": lambda: ChatGoogleGenerativeAI(
-                model="gemini-3.1-flash-lite-preview", temperature=0.7
-            ),
-            "gemini-3.1-pro-preview": lambda: ChatGoogleGenerativeAI(  # LATEST most capable Gemini
-                model="gemini-3.1-pro-preview", temperature=0.7
-            ),
-            # ── DeepSeek ───────────────────────────────────────────────────────
-            # LEGACY: older coder-specific model
-            "deepseek-7b": lambda: ChatDeepSeek(
-                model="deepseek-ai/deepseek-coder-7b-instruct", temperature=0.7
-            ),
-            # LATEST: DeepSeek-V3 general chat model (auto-updated by DeepSeek API)
-            "deepseek-v3": lambda: ChatDeepSeek(model="deepseek-chat", temperature=0.7),
-            # LATEST: DeepSeek-R1 reasoning model (Jan 2025)
-            "deepseek-r1": lambda: ChatDeepSeek(
-                model="deepseek-reasoner", temperature=0.7
-            ),
-            # ── Z.AI / GLM (OpenAI-compatible endpoint) ────────────────────────
-            "glm-5.2": lambda: ChatOpenAI(  # z.ai GLM via OpenAI-compat base_url; key = ZAI_API_KEY
-                model="glm-5.2",
-                base_url="https://api.z.ai/api/paas/v4/",
-                api_key=os.environ["ZAI_API_KEY"],
-                temperature=0.7,
-            ),
-        }
-
+        self._deployments: Dict[str, dict] = _build_deployments()
         # Cache for instantiated models
         self._models: Dict[str, Any] = {}
 
     def get_model(self, model_name: str):
-        """Get or create a model instance by name"""
-        if model_name not in self._model_factories:
+        """Resolve a named deployment to a client, binding its intended credential."""
+        if model_name not in self._deployments:
             raise ValueError(
-                f"Model {model_name} not found. Available models: {', '.join(self._model_factories.keys())}"
+                f"Model {model_name} not found. Available models: "
+                f"{', '.join(self._deployments.keys())}"
             )
 
-        # Return cached instance if it exists
         if model_name in self._models:
             return self._models[model_name]
 
-        # Create new instance
-        model = self._model_factories[model_name]()
+        d = self._deployments[model_name]
+
+        # Explicit, fail-fast credential resolution: the deployment names the one
+        # env var it is allowed to use; no ambient/implicit SDK key fallback.
+        api_key = os.environ.get(d["credential_ref"])
+        if not api_key:
+            raise RuntimeError(
+                f"Deployment '{model_name}' requires credential '{d['credential_ref']}', "
+                f"but that environment variable is unset."
+            )
+
+        adapter = _ADAPTERS[d["provider"]]
+        model = adapter(d, api_key)
         self._models[model_name] = model
         return model
 
     def list_models(self) -> list[str]:
-        return list(self._model_factories.keys())
+        return list(self._deployments.keys())


### PR DESCRIPTION
# Refactor the model registry into explicit named deployments

   ## Summary

   Reworks `LangChainRegistry` from a flat map of hardcoded per-model lambdas into a **data-driven named-deployment registry**. Each
 entry is now an explicit binding of a logical model name to `{ provider adapter, endpoint, credential, upstream model, params }`.
 The headline change is **how the API key is selected**: every deployment names the single environment variable it is allowed to use,
 resolved fail-fast at call time — instead of relying on each provider SDK silently reading whatever key happens to be in the
 environment.

   The public API (`get_model`, `list_models`) is unchanged, so no callers were touched.

   ## Motivation

   The previous registry conflated three independent concerns in one lambda:

   ```python
   "claude-opus-5": lambda: ChatAnthropic(model_name="claude-opus-5", ...)
   ```

   - **model identity** (`"claude-opus-5"`),
   - **deployment** (which client class + endpoint), and
   - **credential** — which was never stated; it depended on the SDK reading an ambient `ANTHROPIC_API_KEY`.

   That implicit key resolution works only when there is exactly one deployment per provider. It breaks the moment you have the same
 model behind two keys, a proxy (LiteLLM / OpenRouter / Azure) whose client type no longer matches the backend, or several backends
 for one logical model. It also fails silently — the wrong key is used rather than an error being raised.

   ## What changed

   ### `incalmo/core/strategies/llm/langchain_registry.py`
   - **Explicit, fail-fast credentials.** Each deployment declares a `credential_ref` (an env-var *name*). `get_model()` resolves it
 at call time and raises a clear error if unset — no ambient/implicit SDK key fallback.
   - **Provider-adapter factory.** A small map (`openai`, `openai_compatible`, `anthropic`, `google`, `deepseek`) knows how to build
 each client and where to inject the key + `base_url`. Adding a backend is a data edit, not new code.
   - **`base_url` indirection.** Supports a literal URL, `None` (provider default), or an `env/VAR` reference resolved at build time
 (used for the proxy URL).
   - **All existing models preserved** as vendor-direct deployments with identical params — Claude temperatures (incl. Claude-5's
 required `temperature=1`), the `o1-preview` alias, GLM's z.ai OpenAI-compatible endpoint, etc.
   - **LiteLLM-proxied twins** (`<name>-litellm`) that route through one OpenAI-compatible endpoint via `LITELLM_BASE_URL` /
 `LITELLM_API_KEY`, so a single key can drive many frontier models. Model ids match the CMU AI gateway catalog. Includes small GPTs
 (`gpt-5-mini-litellm`, …) and frontier Claude/Gemini/GPT models.
   - **Kimi (Moonshot) wired up** via OpenRouter's OpenAI-compatible endpoint (`moonshotai/kimi-k3`, `OPENROUTER_API_KEY`,
 `OPENROUTER_BASE_URL` override).

   ### `.env.example`
   - Documents every credential the registry now reads — `DEEPSEEK_API_KEY`, `ZAI_API_KEY`, `OPENROUTER_API_KEY`, and the LiteLLM
 proxy vars (`LITELLM_API_KEY` / `LITELLM_BASE_URL`) — grouped and commented, so the tracked contract matches what the code actually
 reads.

   ## Design

   ```
     logical name          deployment binding              credential
    ┌──────────────┐      ┌────────────────────┐          ┌──────────────────┐
    │ "opus-eval"  │─────▶│ provider: anthropic │──ref────▶│ ANTHROPIC_KEY... │
    └──────────────┘      │ endpoint / model    │          │ (resolved from   │
                          │ credential_ref      │          │  env, fail-fast) │
                          └────────────────────┘          └──────────────────┘
   ```

   Switching a model between vendor-direct and a proxy (LiteLLM / OpenRouter) is now a per-entry data change — same
 `openai_compatible` adapter, different `base_url` + `credential_ref`.

   ## Behavior / compatibility

   - **No API change.** `get_model(name)` and `list_models()` are unchanged; 76 deployments load.
   - **Backward compatible names.** Every previously valid model name still resolves with the same client and params.
   - **New failure mode (intentional):** requesting a deployment whose `credential_ref` is unset now raises immediately with a
 descriptive message, instead of proceeding with an implicit/ambient key.

   ## Testing

   - Registry imports and builds all 76 deployments.
   - Verified fail-fast when a required credential env var is missing (OpenAI, LiteLLM base_url, Kimi/OpenRouter).
   - Verified vendor-direct entries keep their original params (e.g. direct `claude-sonnet-4-6` → `temperature=0.7`) while the
 `-litellm` twins set no sampling params (provider default), matching the OpenAI direct deployments.
   - Confirmed live: the `-litellm` deployments reach the CMU gateway (`claude-sonnet-4-6-litellm`, `gpt-5.5-litellm`,
 `gemini-2.5-pro-litellm` returned responses); `moonshotai/kimi-k3` is a valid OpenRouter model id.

   ## Notes for reviewers

   - **Kimi model id** (`moonshotai/kimi-k3`) is verified against OpenRouter's public catalog; `OPENROUTER_API_KEY` is intentionally
 left empty until a key is provisioned.
   - **LiteLLM model strings** must match the proxy's configured `model_name`s (the CMU gateway catalog); update the
 `_LITELLM_MODELS` list if the gateway's offerings change.
   - Downstream: the experiment-harness model picker references these deployment names, so it should land/deploy after this PR.